### PR TITLE
Create undercover-report command

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-undercover (1.0.0)
+    danger-undercover (1.1.0)
       danger-plugin-api (~> 1.0)
 
 GEM
@@ -19,7 +19,7 @@ GEM
     colored2 (3.1.2)
     cork (0.3.0)
       colored2 (~> 3.1)
-    danger (8.0.6)
+    danger (8.1.0)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
@@ -35,8 +35,9 @@ GEM
     danger-plugin-api (1.0.0)
       danger (> 2.0)
     diff-lcs (1.4.4)
-    faraday (1.0.1)
+    faraday (1.1.0)
       multipart-post (>= 1.2, < 3)
+      ruby2_keywords
     faraday-http-cache (2.2.0)
       faraday (>= 0.8)
     ffi (1.13.1)
@@ -117,6 +118,7 @@ GEM
     rubocop-ast (0.7.1)
       parser (>= 2.7.1.5)
     ruby-progressbar (1.10.1)
+    ruby2_keywords (0.0.2)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)

--- a/README.md
+++ b/README.md
@@ -15,10 +15,16 @@ To know more about running undercover [visit here](https://github.com/grodowski/
 > Use the `-c --compare ref` flag to specify a git ref (commit hash, branch name, tag) to compare against. 
 **This is a recommended usage for CI/CD build environments**, as `undercover` will `exit 1` if there are any warnings.
 
-Run the below command to output undercover report to a `txt` file which this plugin will use to geneate PR comments.
-To use it on a CI server, run this command before running `Danger` so that the file is created beforehand.
+This plugin provides a command `undercover-report` that uses `undercover` command from 
+[Undercover](https://github.com/grodowski/undercover) gem. It takes all the options that `undercover` command takes.
 
-    $ undercover -c $compare_git_ref > coverage/undercover.txt
+They both works in the same way but what `undercover-report` extra does is it prints `undercover` report to a default
+ file in `coverage/undercover.txt`. This makes using `undercover` in CI server much easier.
+
+To use it on a CI server, run the below command before running `Danger` so that the report file is created beforehand
+ which `Danger` will use..
+
+    $ undercover-report -c $compare_git_ref
 
 >Here $compare_git_ref as per undercover documentation, can be a commit hash, branch name, or tag. i.e. origin/master
 , origin/development
@@ -27,7 +33,7 @@ To use it on a CI server, run this command before running `Danger` so that the f
 Then in your `Dangerfile` add the following line with the output file 
 
 ```ruby
-undercover.report 'coverage/undercover.txt'
+undercover.report
 ```
 
 ## Development

--- a/bin/undercover-report
+++ b/bin/undercover-report
@@ -1,0 +1,10 @@
+# bin/undercover_report
+
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift("#{__dir__}/../lib")
+
+require 'undercover/cli'
+
+puts DangerUndercover::CLI.run(ARGV)

--- a/lib/undercover/cli.rb
+++ b/lib/undercover/cli.rb
@@ -11,7 +11,8 @@ module DangerUndercover
       # @return  [String]
       #
       def run(args = nil)
-        undercover_output = `undercover #{args}`
+        undercover_output = `undercover #{args.join(' ')}`
+
         File.open(output_file, 'w') do |f|
           f.write(undercover_output)
         end

--- a/lib/undercover/cli.rb
+++ b/lib/undercover/cli.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+
+module DangerUndercover
+  # module for undercover-report
+  module CLI
+    class << self
+      # Runs the undercover command with provided arguments
+      # and writes the output to a file
+      # @return  [String]
+      #
+      def run(args = nil)
+        undercover_output = `undercover #{args}`
+        File.open(output_file, 'w') do |f|
+          f.write(undercover_output)
+        end
+
+        undercover_output
+      end
+
+      private
+
+      # Returns the file to write report to
+      # @return  [String]
+      #
+      def output_file
+        create_directory!
+
+        File.join(output_directory, 'undercover.txt')
+      end
+
+      # Creates directory if doesn't exists
+      # @return  [String]
+      #
+      def create_directory!
+        return if Dir.exist?(output_directory)
+
+        FileUtils.mkdir_p(output_directory)
+      end
+
+      # Output directory
+      # @return  [String]
+      #
+      def output_directory
+        File.join(Dir.getwd, 'coverage')
+      end
+    end
+  end
+end

--- a/lib/undercover/cli.rb
+++ b/lib/undercover/cli.rb
@@ -11,7 +11,7 @@ module DangerUndercover
       # @return  [String]
       #
       def run(args = nil)
-        undercover_output = `undercover #{args.join(' ')}`
+        undercover_output = `undercover #{args&.join(' ')}`
 
         File.open(output_file, 'w') do |f|
           f.write(undercover_output)

--- a/lib/undercover/gem_version.rb
+++ b/lib/undercover/gem_version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Undercover
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/lib/undercover/plugin.rb
+++ b/lib/undercover/plugin.rb
@@ -23,15 +23,15 @@ module Danger
     # If there are reports then it shows the report as a warning in danger.
     # @return  [void]
     #
-    def report(undercover_path, sticky: true)
+    def report(undercover_path = 'coverage/undercover.txt', sticky: true)
       return fail('Undercover: coverage report cannot be found.') unless valid_file? undercover_path
 
-      report = File.open(undercover_path).read
+      report = File.open(undercover_path).read.force_encoding('UTF-8')
 
-      if report.match(/No coverage is missing in latest changes/)
-        message(report, sticky: sticky)
-      else
+      if report.match(/some methods have no test coverage/)
         warn(report, sticky: sticky)
+      else
+        message(report, sticky: sticky)
       end
     end
 

--- a/lib/undercover/plugin.rb
+++ b/lib/undercover/plugin.rb
@@ -16,6 +16,7 @@ module Danger
   #
   class DangerUndercover < Plugin
     VALID_FILE_FORMAT = '.txt'
+    DEFAULT_PATH = 'coverage/undercover.txt'
 
     # Checks the file validity and warns if no file is found
     # if a valid file is found then if there are no changes,
@@ -23,7 +24,7 @@ module Danger
     # If there are reports then it shows the report as a warning in danger.
     # @return  [void]
     #
-    def report(undercover_path = 'coverage/undercover.txt', sticky: true)
+    def report(undercover_path = DEFAULT_PATH, sticky: true)
       return fail('Undercover: coverage report cannot be found.') unless valid_file? undercover_path
 
       report = File.open(undercover_path).read.force_encoding('UTF-8')

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -7,14 +7,16 @@ require 'undercover/cli'
 module DangerUndercover
   describe DangerUndercover::CLI do
     let!(:mock_message) { 'Test Passed' }
-    let!(:directory) { File.join(Dir.getwd, 'coverage') }
-    let!(:file) { File.join(Dir.getwd, 'coverage/undercover.txt') }
+    let!(:directory) { File.join(Dir.getwd, 'coverage') } # default directory
+    let!(:file) { File.join(Dir.getwd, 'coverage/undercover.txt') } # default file
 
     before(:each) do
+      # mocks the undercover #{args&.join(' ')} CLI command output.
       allow(described_class).to receive(:`).and_return(mock_message)
     end
 
     after(:all) do
+      # removes the folder after tests pass.
       FileUtils.rm_rf(File.join(Dir.getwd, 'coverage'))
     end
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require File.expand_path('spec_helper', __dir__)
+require 'undercover/cli'
+
+# rubocop:disable Metrics/BlockLength
+module DangerUndercover
+  describe DangerUndercover::CLI do
+    let!(:mock_message) { 'Test Passed' }
+    let!(:directory) { File.join(Dir.getwd, 'coverage') }
+    let!(:file) { File.join(Dir.getwd, 'coverage/undercover.txt') }
+
+    before(:each) do
+      allow(described_class).to receive(:`).and_return(mock_message)
+    end
+
+    after(:all) do
+      FileUtils.rm_rf(File.join(Dir.getwd, 'coverage'))
+    end
+
+    it 'prints the undercover output' do
+      expect(described_class.run).to eql(mock_message)
+    end
+
+    it "creates a default folder if doesn't exists" do
+      FileUtils.rm_rf(directory)
+      described_class.run
+
+      expect(Dir.exist?(directory)).to be true
+    end
+
+    it 'creates default file undercover.txt' do
+      described_class.run
+
+      expect(File.exist?(file)).to be true
+    end
+
+    it 'writes undercover report to default file' do
+      described_class.run
+      report = File.open(file).read
+
+      expect(report).to eql(mock_message)
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
## What happened 👀

The previous method to create the report `undercover -c $compare_git_ref > coverage/undercover.txt` was not so user friendly.
 
## Insight 📝

To fix this we created a new CLI command `undercover-report` which takes the same arguments as `undercover` and saves the output in a file for the `danger-undercover` to read from.

`undercover-report -c origin/development` 

## Proof Of Work 📹

Tested the implementation in our internal project and it's working seamlessly 🤩 

- No Changes

![image](https://user-images.githubusercontent.com/14927672/96212395-9ab60d80-0f98-11eb-950a-494cca591e98.png)

- Changes in new commits

![image](https://user-images.githubusercontent.com/14927672/96212414-a99cc000-0f98-11eb-9b07-c74b9fc2de1c.png)
